### PR TITLE
Rewrote classes for author fix

### DIFF
--- a/src/main/java/dev/roryclaasen/vcsparser/measures/ComputeNumAuthorsMetric.java
+++ b/src/main/java/dev/roryclaasen/vcsparser/measures/ComputeNumAuthorsMetric.java
@@ -7,6 +7,7 @@ import static dev.roryclaasen.vcsparser.metrics.MetricKeyConverter.getAllDatesFo
 
 import java.util.Collection;
 import java.util.Date;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +36,6 @@ public class ComputeNumAuthorsMetric implements MeasureComputer {
 	private PluginMetric numAuthors = PluginMetric.NUM_AUTHORS;
 	private PluginMetric numAuthors10Perc = PluginMetric.NUM_AUTHORS_10_PERC;
 
-	// authorsCache[project][date][file][author] = over10perc
 	protected static Map<String, Map<MetricDate, NavigableMap<String, Map<String, Boolean>>>> authorsCache = new HashMap<String, Map<MetricDate, NavigableMap<String, Map<String, Boolean>>>>();
 
 	private double threshold = 10.0;
@@ -54,15 +54,12 @@ public class ComputeNumAuthorsMetric implements MeasureComputer {
 	}
 
 	protected void saveProjectCache(String projectKey, MetricDate date, String currentKey, Map<String, Boolean> authorMap) {
-		// Project (projectKey)
 		if (!authorsCache.containsKey(projectKey))
-			authorsCache.put(projectKey, new HashMap<MetricDate, NavigableMap<String, Map<String, Boolean>>>());
+			authorsCache.put(projectKey, new EnumMap<MetricDate, NavigableMap<String, Map<String, Boolean>>>(MetricDate.class));
 
-		// Metric Date
 		if (!authorsCache.get(projectKey).containsKey(date))
 			authorsCache.get(projectKey).put(date, new TreeMap<String, Map<String, Boolean>>());
 
-		// File (currentKey)
 		if (!authorsCache.get(projectKey).get(date).containsKey(currentKey))
 			authorsCache.get(projectKey).get(date).put(currentKey, new HashMap<String, Boolean>());
 
@@ -95,7 +92,7 @@ public class ComputeNumAuthorsMetric implements MeasureComputer {
 			case PROJECT:
 			case MODULE:
 			case DIRECTORY:
-				computeChildMeasure(context, date, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+				computeChildMeasure(context, date, numAuthorsKey, numAuthors10PercKey);
 				break;
 			case FILE:
 				computeFileMeasure(context, date, authorsData, numAuthorsKey, numAuthors10PercKey, numChangesKey);
@@ -106,7 +103,7 @@ public class ComputeNumAuthorsMetric implements MeasureComputer {
 		}
 	}
 
-	protected void computeChildMeasure(MeasureComputerContext context, MetricDate date, String numAuthorsKey, String numAuthors10PercKey, String numChangesKey) {
+	protected void computeChildMeasure(MeasureComputerContext context, MetricDate date, String numAuthorsKey, String numAuthors10PercKey) {
 		String currentKey = context.getComponent().getKey();
 		String projectKey = currentKey.split(":", 2)[0];
 

--- a/src/test/java/dev/roryclaasen/vcsparser/measures/TestComputeNumAuthorsMetric.java
+++ b/src/test/java/dev/roryclaasen/vcsparser/measures/TestComputeNumAuthorsMetric.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -115,7 +116,7 @@ public class TestComputeNumAuthorsMetric {
 	}
 
 	private void addAuthorToCache(String project, MetricDate date, String file, String name, boolean value) {
-		ComputeNumAuthorsMetric.authorsCache.putIfAbsent(project, new HashMap<MetricDate, NavigableMap<String, Map<String, Boolean>>>());
+		ComputeNumAuthorsMetric.authorsCache.putIfAbsent(project, new EnumMap<MetricDate, NavigableMap<String, Map<String, Boolean>>>(MetricDate.class));
 		ComputeNumAuthorsMetric.authorsCache.get(project).putIfAbsent(date, new TreeMap<String, Map<String, Boolean>>());
 		ComputeNumAuthorsMetric.authorsCache.get(project).get(date).putIfAbsent(file, new HashMap<String, Boolean>());
 		ComputeNumAuthorsMetric.authorsCache.get(project).get(date).get(file).putIfAbsent(name, value);
@@ -127,7 +128,7 @@ public class TestComputeNumAuthorsMetric {
 
 	@Test
 	void givenComputeNumAuthorsMetric_whenRemoveProjectCacheAndKeyMissing_thenDoNotRemove() {
-		ComputeNumAuthorsMetric.authorsCache.put("SomeOtherProjectKey", new HashMap<MetricDate, NavigableMap<String, Map<String, Boolean>>>());
+		ComputeNumAuthorsMetric.authorsCache.put("SomeOtherProjectKey", new EnumMap<MetricDate, NavigableMap<String, Map<String, Boolean>>>(MetricDate.class));
 
 		computer.removeProjectCache(projectKey);
 
@@ -136,7 +137,7 @@ public class TestComputeNumAuthorsMetric {
 
 	@Test
 	void givenComputeNumAuthorsMetric_whenRemoveProjectCacheAndKeyMatched_thenRemove() {
-		ComputeNumAuthorsMetric.authorsCache.put(projectKey, new HashMap<MetricDate, NavigableMap<String, Map<String, Boolean>>>());
+		ComputeNumAuthorsMetric.authorsCache.put(projectKey, new EnumMap<MetricDate, NavigableMap<String, Map<String, Boolean>>>(MetricDate.class));
 
 		computer.removeProjectCache(projectKey);
 
@@ -327,7 +328,7 @@ public class TestComputeNumAuthorsMetric {
 
 	@Test
 	void givenComputeNumAuthorsMetric_whenComputeChildMeasureAndMissingProjectInCache_thenReturn() {
-		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey);
 
 		verify(context, times(0)).addMeasure(eq(numAuthorsKey), anyInt());
 		verify(context, times(0)).addMeasure(eq(numAuthors10PercKey), anyInt());
@@ -335,10 +336,10 @@ public class TestComputeNumAuthorsMetric {
 
 	@Test
 	void givenComputeNumAuthorsMetric_whenComputeChildMeasureAndMissingDateProjectInCache_thenReturn() {
-		ComputeNumAuthorsMetric.authorsCache.putIfAbsent(projectKey, new HashMap<MetricDate, NavigableMap<String, Map<String, Boolean>>>());
-		
-		
-		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+		ComputeNumAuthorsMetric.authorsCache.putIfAbsent(projectKey, new EnumMap<MetricDate, NavigableMap<String, Map<String, Boolean>>>(MetricDate.class));
+
+
+		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey);
 
 		verify(context, times(0)).addMeasure(eq(numAuthorsKey), anyInt());
 		verify(context, times(0)).addMeasure(eq(numAuthors10PercKey), anyInt());
@@ -348,7 +349,7 @@ public class TestComputeNumAuthorsMetric {
 	void givenComputeNumAuthorsMetric_whenComputeChildMeasureAndIncorrectSubMapFilter_thenDoNotAddMeasure() {
 		addAuthorToCache(projectKey, metricDate, "A Bad Component Key", "Author 1", true);
 
-		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey);
 
 		verify(context, times(0)).addMeasure(eq(numAuthorsKey), anyInt());
 		verify(context, times(0)).addMeasure(eq(numAuthors10PercKey), anyInt());
@@ -358,7 +359,7 @@ public class TestComputeNumAuthorsMetric {
 	void givenComputeNumAuthorsMetric_whenComputeChildMeasure_thenAddMeasures() {
 		addAuthorToCache("Author 1", true);
 
-		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey);
 
 		verify(context, times(1)).addMeasure(eq(numAuthorsKey), eq(1));
 		verify(context, times(1)).addMeasure(eq(numAuthors10PercKey), eq(1));
@@ -368,7 +369,7 @@ public class TestComputeNumAuthorsMetric {
 	void givenComputeNumAuthorsMetric_whenComputeChildMeasureAndAuthorFalse_thenAddNumAuthorsKeyMeasure() {
 		addAuthorToCache("Author 1", false);
 
-		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey);
 
 		verify(context, times(1)).addMeasure(eq(numAuthorsKey), eq(1));
 		verify(context, times(0)).addMeasure(eq(numAuthors10PercKey), anyInt());
@@ -379,7 +380,7 @@ public class TestComputeNumAuthorsMetric {
 		addAuthorToCache("Author 1", false);
 		addAuthorToCache(projectKey, metricDate, componentKey + ".ext", "Author 1", false);
 
-		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey);
 
 		verify(context, times(1)).addMeasure(eq(numAuthorsKey), eq(1));
 		verify(context, times(0)).addMeasure(eq(numAuthors10PercKey), anyInt());
@@ -390,7 +391,7 @@ public class TestComputeNumAuthorsMetric {
 		addAuthorToCache("Author 1", false);
 		addAuthorToCache(projectKey, metricDate, componentKey + ".ext", "Author 1", true);
 
-		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey);
 
 		verify(context, times(1)).addMeasure(eq(numAuthorsKey), eq(1));
 		verify(context, times(1)).addMeasure(eq(numAuthors10PercKey), eq(1));
@@ -401,7 +402,7 @@ public class TestComputeNumAuthorsMetric {
 		addAuthorToCache("Author 1", true);
 		addAuthorToCache(projectKey, metricDate, componentKey + ".ext", "Author 1", false);
 
-		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey);
 
 		verify(context, times(1)).addMeasure(eq(numAuthorsKey), eq(1));
 		verify(context, times(1)).addMeasure(eq(numAuthors10PercKey), eq(1));

--- a/src/test/java/dev/roryclaasen/vcsparser/measures/TestComputeNumAuthorsMetric.java
+++ b/src/test/java/dev/roryclaasen/vcsparser/measures/TestComputeNumAuthorsMetric.java
@@ -13,6 +13,9 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.TreeMap;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,6 +35,7 @@ import dev.roryclaasen.vcsparser.authors.Author;
 import dev.roryclaasen.vcsparser.authors.AuthorData;
 import dev.roryclaasen.vcsparser.authors.AuthorListConverter;
 import dev.roryclaasen.vcsparser.authors.JsonAuthorParser;
+import dev.roryclaasen.vcsparser.metrics.MetricDate;
 import dev.roryclaasen.vcsparser.metrics.PluginMetric;
 
 public class TestComputeNumAuthorsMetric {
@@ -55,21 +59,24 @@ public class TestComputeNumAuthorsMetric {
 
 	@Mock
 	private JsonAuthorParser jsonParser;
-	
+
 	@Mock
 	private AuthorListConverter converter;
 
 	private ComputeNumAuthorsMetric computer;
 
 	private Map<String, Integer> authorChangesMap;
+	private Map<String, Boolean> authorOverMap;
 
 	private final String projectKey = "SomeProjectKey";
 	private final String fileKey = ":path/to.file";
 	private final String componentKey = projectKey + fileKey;
+	private final MetricDate metricDate = MetricDate.DAY_1;
 	private final String authorsDataKey = "SomeAuthorsDataKey";
 	private final String numChangesKey = "SomeNumChangesKey_1d";
 	private final String numAuthorsKey = "SomeNumAuthorsKey_1d";
 	private final String numAuthors10PercKey = "SomeNumAuthors10PercKey_1d";
+	private final int numChanges = 10;
 	private final String jsonArray = "[{},{},{}]";
 
 	@BeforeEach
@@ -87,38 +94,111 @@ public class TestComputeNumAuthorsMetric {
 		when(context.getComponent()).thenReturn(component);
 		when(context.getMeasure(anyString())).thenReturn(measure);
 
-		when(measure.getIntValue()).thenReturn(10);
+		when(measure.getIntValue()).thenReturn(numChanges);
 		when(measure.getStringValue()).thenReturn(jsonArray);
 
 		authorChangesMap = new HashMap<String, Integer>();
 		authorChangesMap.put("Author 1", 9);
 		authorChangesMap.put("Author 2", 1);
 
+		authorOverMap = new HashMap<String, Boolean>();
+		authorOverMap.put("Author 1", true);
+		authorOverMap.put("Author 2", false);
+
+		when(jsonParser.jsonStringArrayToAuthorDataList(jsonArray)).thenReturn(Arrays.asList(new AuthorData(new Date(), new ArrayList<Author>())));
+
 		when(converter.getAuthorListAfterDate(anyList(), any(Date.class))).thenReturn(new ArrayList<Author>());
 		when(converter.getNumChangesPerAuthor(anyMap(), anyList())).thenReturn(authorChangesMap);
-
-		when(measure.getIntValue()).thenReturn(10);
 
 		computer = new ComputeNumAuthorsMetric(jsonParser, converter);
 		ComputeNumAuthorsMetric.authorsCache.clear();
 	}
 
+	private void addAuthorToCache(String project, MetricDate date, String file, String name, boolean value) {
+		ComputeNumAuthorsMetric.authorsCache.putIfAbsent(project, new HashMap<MetricDate, NavigableMap<String, Map<String, Boolean>>>());
+		ComputeNumAuthorsMetric.authorsCache.get(project).putIfAbsent(date, new TreeMap<String, Map<String, Boolean>>());
+		ComputeNumAuthorsMetric.authorsCache.get(project).get(date).putIfAbsent(file, new HashMap<String, Boolean>());
+		ComputeNumAuthorsMetric.authorsCache.get(project).get(date).get(file).putIfAbsent(name, value);
+	}
+
+	private void addAuthorToCache(String name, boolean value) {
+		addAuthorToCache(projectKey, metricDate, componentKey, name, value);
+	}
+
 	@Test
 	void givenComputeNumAuthorsMetric_whenRemoveProjectCacheAndKeyMissing_thenDoNotRemove() {
-		ComputeNumAuthorsMetric.authorsCache.put("SomeOtherProjectKey", new HashMap<String, List<AuthorData>>());
+		ComputeNumAuthorsMetric.authorsCache.put("SomeOtherProjectKey", new HashMap<MetricDate, NavigableMap<String, Map<String, Boolean>>>());
 
-		computer.removeProjectCache(componentKey);
+		computer.removeProjectCache(projectKey);
 
 		assertEquals(1, ComputeNumAuthorsMetric.authorsCache.size());
 	}
 
 	@Test
 	void givenComputeNumAuthorsMetric_whenRemoveProjectCacheAndKeyMatched_thenRemove() {
-		ComputeNumAuthorsMetric.authorsCache.put(componentKey, new HashMap<String, List<AuthorData>>());
+		ComputeNumAuthorsMetric.authorsCache.put(projectKey, new HashMap<MetricDate, NavigableMap<String, Map<String, Boolean>>>());
 
-		computer.removeProjectCache(componentKey);
+		computer.removeProjectCache(projectKey);
 
 		assertEquals(0, ComputeNumAuthorsMetric.authorsCache.size());
+	}
+
+	@Test
+	void givenComputeNumAuthorsMetric_whenSaveProjectCacheAndNoExistingProject_thenPutMapsAndAddAuthorMap() {
+		computer.saveProjectCache(projectKey, metricDate, componentKey, authorOverMap);
+
+		assertTrue(ComputeNumAuthorsMetric.authorsCache.containsKey(projectKey));
+		assertTrue(ComputeNumAuthorsMetric.authorsCache.get(projectKey).containsKey(metricDate));
+		assertTrue(ComputeNumAuthorsMetric.authorsCache.get(projectKey).get(metricDate).containsKey(componentKey));
+		assertEquals(2, ComputeNumAuthorsMetric.authorsCache.get(projectKey).get(metricDate).get(componentKey).size());
+	}
+
+	@Test
+	void givenComputeNumAuthorsMetric_whenSaveProjectCacheAndExistingAuthorFalseAndInputTrue_thenSetTrue() {
+		addAuthorToCache("Author 1", false);
+
+		Map<String, Boolean> authorMap = new HashMap<String, Boolean>();
+		authorMap.put("Author 1", true);
+
+		computer.saveProjectCache(projectKey, metricDate, componentKey, authorMap);
+
+		assertTrue(ComputeNumAuthorsMetric.authorsCache.get(projectKey).get(metricDate).get(componentKey).get("Author 1"));
+	}
+
+	@Test
+	void givenComputeNumAuthorsMetric_whenSaveProjectCacheAndExistingAuthorTrueandInputFalse_thenDoNotSet() {
+		addAuthorToCache("Author 1", true);
+
+		Map<String, Boolean> authorMap = new HashMap<String, Boolean>();
+		authorMap.put("Author 1", false);
+
+		computer.saveProjectCache(projectKey, metricDate, componentKey, authorMap);
+
+		assertTrue(ComputeNumAuthorsMetric.authorsCache.get(projectKey).get(metricDate).get(componentKey).get("Author 1"));
+	}
+
+	@Test
+	void givenComputeNumAuthorsMetric_whenSaveProjectCacheAndExistingAuthorTrueAndInputTrue_thenSetTrue() {
+		addAuthorToCache("Author 1", true);
+
+		Map<String, Boolean> authorMap = new HashMap<String, Boolean>();
+		authorMap.put("Author 1", true);
+
+		computer.saveProjectCache(projectKey, metricDate, componentKey, authorMap);
+
+		assertTrue(ComputeNumAuthorsMetric.authorsCache.get(projectKey).get(metricDate).get(componentKey).get("Author 1"));
+	}
+
+	@Test
+	void givenComputeNumAuthorsMetric_whenSaveProjectCacheAndExistingAuthorFalseAndInputFalse_thenDoNotSet() {
+		addAuthorToCache("Author 1", false);
+
+		Map<String, Boolean> authorMap = new HashMap<String, Boolean>();
+		authorMap.put("Author 1", false);
+
+		computer.saveProjectCache(projectKey, metricDate, componentKey, authorMap);
+
+		assertFalse(ComputeNumAuthorsMetric.authorsCache.get(projectKey).get(metricDate).get(componentKey).get("Author 1"));
 	}
 
 	@Test
@@ -130,75 +210,82 @@ public class TestComputeNumAuthorsMetric {
 	}
 
 	@Test
-	void givenComputeNumAuthorsMetric_whenGetAuthorNumChangesAfterDateDict_thenReturnMap() {
+	void givenComputeNumAuthorsMetric_whenGetAuthorIsOverAfterDateDict_thenReturnMap() {
 		List<AuthorData> authorDataList = new ArrayList<AuthorData>();
 		List<Author> authorList = new ArrayList<Author>();
-		Map<String, Integer> authorChangesMap = new HashMap<String, Integer>();
 		Date dateFrom = new Date();
 
 		when(converter.getAuthorListAfterDate(anyList(), any(Date.class))).thenReturn(authorList);
 		when(converter.getNumChangesPerAuthor(anyMap(), anyList())).thenReturn(authorChangesMap);
 
-		Map<String, Integer> returnedMap = computer.getAuthorNumChangesAfterDateDict(authorDataList, dateFrom, authorChangesMap);
+		Map<String, Boolean> returnedMap = computer.getAuthorIsOverAfterDateDict(authorDataList, dateFrom, numChanges);
 
-		assertEquals(authorChangesMap, returnedMap);
 		verify(converter, times(1)).getAuthorListAfterDate(eq(authorDataList), eq(dateFrom));
-		verify(converter, times(1)).getNumChangesPerAuthor(eq(authorChangesMap), eq(authorList));
+		verify(converter, times(1)).getNumChangesPerAuthor(anyMap(), eq(authorList));
+		assertEquals(authorOverMap, returnedMap);
+	}
+
+	@Test
+	void givenComputeNumAuthorsMetric_whenGetAuthorIsOverAfterDateDictAndNumChangesZero_thenReturnMapEntriesFalse() {
+		List<AuthorData> authorDataList = new ArrayList<AuthorData>();
+		List<Author> authorList = new ArrayList<Author>();
+		Date dateFrom = new Date();
+
+		when(converter.getAuthorListAfterDate(anyList(), any(Date.class))).thenReturn(authorList);
+		when(converter.getNumChangesPerAuthor(anyMap(), anyList())).thenReturn(authorChangesMap);
+
+		Map<String, Boolean> returnedMap = computer.getAuthorIsOverAfterDateDict(authorDataList, dateFrom, 0);
+
+		for (Entry<String, Boolean> entry : returnedMap.entrySet()) {
+			assertFalse(entry.getValue());
+		}
 	}
 
 	@Test
 	void givenComputeNumAuthorsMetric_whenComputNumAuthorsAndEmptyCollection_thenDontAdd() {
-		List<Integer> authorNumChanges = new ArrayList<Integer>();
+		List<Boolean> authorIsOver = new ArrayList<Boolean>();
 
-		computer.computeNumAuthors(context, numAuthorsKey, authorNumChanges);
+		computer.computeNumAuthors(context, numAuthorsKey, authorIsOver);
 
 		verify(context, times(0)).addMeasure(eq(numAuthorsKey), anyInt());
 	}
 
 	@Test
 	void givenComputeNumAuthorsMetric_whenComputNumAuthorsAndCollectionHasItems_thenAddMeasure() {
-		List<Integer> authorNumChanges = new ArrayList<Integer>();
-		authorNumChanges.add(5);
-		authorNumChanges.add(7);
+		List<Boolean> authorIsOver = new ArrayList<Boolean>();
+		authorIsOver.add(false);
+		authorIsOver.add(true);
 
-		computer.computeNumAuthors(context, numAuthorsKey, authorNumChanges);
+		computer.computeNumAuthors(context, numAuthorsKey, authorIsOver);
 
 		verify(context, times(1)).addMeasure(eq(numAuthorsKey), eq(2));
 	}
 
 	@Test
-	void givenComputeNumAuthorsMetric_whenComputeNumAuthorsOver10PercAndMeasureNull_thenReturn() {
-		when(context.getMeasure(numChangesKey)).thenReturn(null);
+	void givenComputeNumAuthorsMetric_whenComputNumAuthorsOver10PercAndEmptyCollection_thenDontAdd() {
+		List<Boolean> authorIsOver = new ArrayList<Boolean>();
 
-		computer.computeNumAuthorsOver10Perc(context, numChangesKey, numAuthors10PercKey, authorChangesMap.values());
+		computer.computeNumAuthorsOver10Perc(context, numAuthors10PercKey, authorIsOver);
 
-		verify(measure, times(0)).getIntValue();
-		verify(context, times(0)).addMeasure(eq(numAuthors10PercKey), anyInt());
+		verify(context, times(0)).addMeasure(eq(numAuthorsKey), anyInt());
 	}
 
 	@Test
-	void givenComputeNumAuthorsMetric_whenComputeNumAuthorsOver10PercAndMeasureValueZero_thenReturn() {
-		when(measure.getIntValue()).thenReturn(0);
+	void givenComputeNumAuthorsMetric_whenComputNumAuthorsOver10PercAndCountZero_thenDontAdd() {
+		List<Boolean> authorIsOver = new ArrayList<Boolean>();
+		authorIsOver.add(false);
 
-		computer.computeNumAuthorsOver10Perc(context, numChangesKey, numAuthors10PercKey, authorChangesMap.values());
+		computer.computeNumAuthorsOver10Perc(context, numAuthors10PercKey, authorIsOver);
 
-		verify(context, times(0)).addMeasure(eq(numAuthors10PercKey), anyInt());
+		verify(context, times(0)).addMeasure(eq(numAuthorsKey), anyInt());
 	}
 
 	@Test
-	void givenComputeNumAuthorsMetric_whenComputeNumAuthorsOver10PercAndListEmpty_thenDontAdd() {
-		List<Integer> authorNumChanges = new ArrayList<Integer>();
+	void givenComputeNumAuthorsMetric_whenComputNumAuthorsOver10PercAndCountGTZero_thenAddMeasure() {
+		List<Boolean> authorIsOver = new ArrayList<Boolean>();
+		authorIsOver.add(true);
 
-		when(measure.getIntValue()).thenReturn(10);
-
-		computer.computeNumAuthorsOver10Perc(context, numChangesKey, numAuthors10PercKey, authorNumChanges);
-
-		verify(context, times(0)).addMeasure(eq(numAuthors10PercKey), anyInt());
-	}
-
-	@Test
-	void givenComputeNumAuthorsMetric_whenComputeNumAuthorsOver10PercAndHasItemsthenAddCountOverThreshold() {
-		computer.computeNumAuthorsOver10Perc(context, numChangesKey, numAuthors10PercKey, authorChangesMap.values());
+		computer.computeNumAuthorsOver10Perc(context, numAuthors10PercKey, authorIsOver);
 
 		verify(context, times(1)).addMeasure(eq(numAuthors10PercKey), eq(1));
 	}
@@ -207,96 +294,122 @@ public class TestComputeNumAuthorsMetric {
 	void givenComputeNumAuthorsMetric_whenComputeFileMeasureAndAuthorsDataNull_thenReturn() {
 		when(context.getMeasure(authorsDataKey)).thenReturn(null);
 
-		computer.computeFileMeasure(context, authorsDataKey, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+		computer.computeFileMeasure(context, metricDate, authorsDataKey, numAuthorsKey, numAuthors10PercKey, numChangesKey);
 
 		verify(measure, times(0)).getStringValue();
 	}
 
 	@Test
-	void givenComputeNumAuthorsMetric_whenComputeFileMeasureAndAuthorsDataListEmpty_thenReturn() {
-		when(jsonParser.jsonStringArrayToAuthorDataList(jsonArray)).thenReturn(new ArrayList<AuthorData>());
+	void givenComputeNumAuthorsMetric_whenComputeFileMeasureAndAuthorsDataEmpty_thenReturn() {
+		when(jsonParser.jsonStringArrayToAuthorDataList(jsonArray)).thenReturn(Arrays.asList());
 
-		computer.computeFileMeasure(context, authorsDataKey, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+		computer.computeFileMeasure(context, metricDate, authorsDataKey, numAuthorsKey, numAuthors10PercKey, numChangesKey);
 
 		assertEquals(0, ComputeNumAuthorsMetric.authorsCache.size());
+		verify(measure, times(0)).getIntValue();
 	}
 
 	@Test
-	void givenComputeNumAuthorsMetric_whenComputeFileMeasureAndCacheMissingKey_thenAddToCache() {
-		List<AuthorData> authorDataList = Arrays.asList(new AuthorData(new Date(), new ArrayList<Author>()));
-		when(jsonParser.jsonStringArrayToAuthorDataList(jsonArray)).thenReturn(authorDataList);
+	void givenComputeNumAuthorsMetric_whenComputeFileMeasureAndNumChangesMeasureNull_thenUseZero() {
+		when(context.getMeasure(numChangesKey)).thenReturn(null);
 
-		computer.computeFileMeasure(context, authorsDataKey, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+		computer.computeFileMeasure(context, metricDate, authorsDataKey, numAuthorsKey, numAuthors10PercKey, numChangesKey);
 
-		assertEquals(1, ComputeNumAuthorsMetric.authorsCache.size());
-		assertArrayEquals(authorDataList.toArray(), ComputeNumAuthorsMetric.authorsCache.get(projectKey).get(componentKey).toArray());
+		verify(measure, times(0)).getIntValue();
 	}
 
 	@Test
-	void givenComputeNumAuthorsMetric_whenComputeFileMeasureAndCacheHasKey_thenAddToCache() {
-		List<AuthorData> authorDataList = Arrays.asList(new AuthorData(new Date(), new ArrayList<Author>()));
-		when(jsonParser.jsonStringArrayToAuthorDataList(jsonArray)).thenReturn(authorDataList);
-		ComputeNumAuthorsMetric.authorsCache.put(projectKey, new HashMap<String, List<AuthorData>>());
+	void givenComputeNumAuthorsMetric_whenComputeFileMeasureAndNumChangesMeasureNotNull_thenUseMeasure() {
+		computer.computeFileMeasure(context, metricDate, authorsDataKey, numAuthorsKey, numAuthors10PercKey, numChangesKey);
 
-		computer.computeFileMeasure(context, authorsDataKey, numAuthorsKey, numAuthors10PercKey, numChangesKey);
-
-		assertEquals(1, ComputeNumAuthorsMetric.authorsCache.size());
-		assertArrayEquals(authorDataList.toArray(), ComputeNumAuthorsMetric.authorsCache.get(projectKey).get(componentKey).toArray());
-	}
-
-	@Test
-	void givenComputeNumAuthorsMetric_whenComputeFileMeasureAndAuthorsDatahasItems_thenAddMeasure() {
-		List<AuthorData> authorDataList = Arrays.asList(new AuthorData(new Date(), new ArrayList<Author>()));
-		when(jsonParser.jsonStringArrayToAuthorDataList(jsonArray)).thenReturn(authorDataList);
-
-		computer.computeFileMeasure(context, authorsDataKey, numAuthorsKey, numAuthors10PercKey, numChangesKey);
-
-		verify(context, times(1)).addMeasure(eq(numAuthorsKey), eq(2));
-		verify(context, times(1)).addMeasure(eq(numAuthors10PercKey), eq(1));
+		verify(measure, times(1)).getIntValue();
 	}
 
 	@Test
 	void givenComputeNumAuthorsMetric_whenComputeChildMeasureAndMissingProjectInCache_thenReturn() {
-		computer.computeChildMeasure(context, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey, numChangesKey);
 
 		verify(context, times(0)).addMeasure(eq(numAuthorsKey), anyInt());
 		verify(context, times(0)).addMeasure(eq(numAuthors10PercKey), anyInt());
 	}
 
 	@Test
-	void givenComputeNumAuthorsMetric_whenComputeChildMeasureAndEntryDoesntStartWithCurrentKey_thenSkip() {
-		Map<String, List<AuthorData>> fileMap = new HashMap<String, List<AuthorData>>();
-		fileMap.put("SomeOtherProjectKey" + fileKey, new ArrayList<AuthorData>());
-
-		ComputeNumAuthorsMetric.authorsCache.put(projectKey, fileMap);
-
-		computer.computeChildMeasure(context, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+	void givenComputeNumAuthorsMetric_whenComputeChildMeasureAndMissingDateProjectInCache_thenReturn() {
+		ComputeNumAuthorsMetric.authorsCache.putIfAbsent(projectKey, new HashMap<MetricDate, NavigableMap<String, Map<String, Boolean>>>());
+		
+		
+		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey, numChangesKey);
 
 		verify(context, times(0)).addMeasure(eq(numAuthorsKey), anyInt());
 		verify(context, times(0)).addMeasure(eq(numAuthors10PercKey), anyInt());
 	}
 
 	@Test
-	void givenComputeNumAuthorsMetric_whenComputeChildMeasureAndEntryStartsWithCurrentKey_thenAddMeasure() {
-		Map<String, List<AuthorData>> fileMap = new HashMap<String, List<AuthorData>>();
-		fileMap.put(componentKey, new ArrayList<AuthorData>());
+	void givenComputeNumAuthorsMetric_whenComputeChildMeasureAndIncorrectSubMapFilter_thenDoNotAddMeasure() {
+		addAuthorToCache(projectKey, metricDate, "A Bad Component Key", "Author 1", true);
 
-		ComputeNumAuthorsMetric.authorsCache.put(projectKey, fileMap);
+		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey, numChangesKey);
 
-		computer.computeChildMeasure(context, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+		verify(context, times(0)).addMeasure(eq(numAuthorsKey), anyInt());
+		verify(context, times(0)).addMeasure(eq(numAuthors10PercKey), anyInt());
+	}
 
-		verify(converter, times(1)).getAuthorListAfterDate(eq(fileMap.get(componentKey)), any(Date.class));
+	@Test
+	void givenComputeNumAuthorsMetric_whenComputeChildMeasure_thenAddMeasures() {
+		addAuthorToCache("Author 1", true);
 
-		verify(context, times(1)).addMeasure(eq(numAuthorsKey), eq(2));
+		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+
+		verify(context, times(1)).addMeasure(eq(numAuthorsKey), eq(1));
+		verify(context, times(1)).addMeasure(eq(numAuthors10PercKey), eq(1));
+	}
+
+	@Test
+	void givenComputeNumAuthorsMetric_whenComputeChildMeasureAndAuthorFalse_thenAddNumAuthorsKeyMeasure() {
+		addAuthorToCache("Author 1", false);
+
+		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+
+		verify(context, times(1)).addMeasure(eq(numAuthorsKey), eq(1));
+		verify(context, times(0)).addMeasure(eq(numAuthors10PercKey), anyInt());
+	}
+
+	@Test
+	void givenComputeNumAuthorsMetric_whenComputeChildMeasureAndSameAuthorFalse_thenAddNumAuthorsKeyMeasure() {
+		addAuthorToCache("Author 1", false);
+		addAuthorToCache(projectKey, metricDate, componentKey + ".ext", "Author 1", false);
+
+		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+
+		verify(context, times(1)).addMeasure(eq(numAuthorsKey), eq(1));
+		verify(context, times(0)).addMeasure(eq(numAuthors10PercKey), anyInt());
+	}
+
+	@Test
+	void givenComputeNumAuthorsMetric_whenComputeChildMeasureAndSameAuthorFalseThenTrue_thenMeasures() {
+		addAuthorToCache("Author 1", false);
+		addAuthorToCache(projectKey, metricDate, componentKey + ".ext", "Author 1", true);
+
+		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+
+		verify(context, times(1)).addMeasure(eq(numAuthorsKey), eq(1));
+		verify(context, times(1)).addMeasure(eq(numAuthors10PercKey), eq(1));
+	}
+
+	@Test
+	void givenComputeNumAuthorsMetric_whenComputeChildMeasureAndSameAuthorTrueThenFalse_thenMeasures() {
+		addAuthorToCache("Author 1", true);
+		addAuthorToCache(projectKey, metricDate, componentKey + ".ext", "Author 1", false);
+
+		computer.computeChildMeasure(context, metricDate, numAuthorsKey, numAuthors10PercKey, numChangesKey);
+
+		verify(context, times(1)).addMeasure(eq(numAuthorsKey), eq(1));
 		verify(context, times(1)).addMeasure(eq(numAuthors10PercKey), eq(1));
 	}
 
 	@Test
 	void givenComputeNumAuthorsMetric_whenComputeAndTypeFile_thenComputeFileMeasure() {
 		when(component.getType()).thenReturn(Type.FILE);
-
-		List<AuthorData> authorDataList = Arrays.asList(new AuthorData(new Date(), new ArrayList<Author>()));
-		when(jsonParser.jsonStringArrayToAuthorDataList(jsonArray)).thenReturn(authorDataList);
 
 		computer.compute(context);
 
@@ -311,12 +424,12 @@ public class TestComputeNumAuthorsMetric {
 	@ParameterizedTest
 	@EnumSource(value = Type.class, names = { "PROJECT", "MODULE", "DIRECTORY" })
 	void givenComputeNumAuthorsMetric_whenComputeAndTypeSupportsChild_thenComputeChildMeasure(Type type) {
+		for (MetricDate date : MetricDate.values()) {
+			addAuthorToCache(projectKey, date, componentKey, "Author 1", true);
+			addAuthorToCache(projectKey, date, componentKey, "Author 2", false);
+		}
+
 		when(component.getType()).thenReturn(type);
-
-		Map<String, List<AuthorData>> fileMap = new HashMap<String, List<AuthorData>>();
-		fileMap.put(componentKey, new ArrayList<AuthorData>());
-
-		ComputeNumAuthorsMetric.authorsCache.put(projectKey, fileMap);
 
 		computer.compute(context);
 


### PR DESCRIPTION
fixes #9 

Compute NumAuthors Metric now will no longer try and calculate if an author is over the threshold on a project level but rather count if a (unique) author is over the threshold per file.

Map syntax syntax
[project key][[time period](https://github.com/roryclaasen/sonar-vcsparser-plugin/blob/master/src/main/java/dev/roryclaasen/vcsparser/metrics/MetricDate.java)][component key][author name] = over threshold.